### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Damien Lecan <dev@dlecan.com>"]
 description = "A cross-platform tool to update DNS zonefiles (such as Gandi.net) when you have a dynamic public IP address."
 homepage = "https://github.com/dlecan/generic-dns-update/"
 repository = "https://github.com/dlecan/generic-dns-update/"
-readme = "README.md"
 license = "MIT"
 
 [[bin]]


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).